### PR TITLE
Add feed conversion ratio KPI and tests

### DIFF
--- a/aquaponics/__init__.py
+++ b/aquaponics/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for aquaponics calculations."""
+
+from .kpis import feed_conversion_ratio
+
+__all__ = ["feed_conversion_ratio"]

--- a/aquaponics/kpis.py
+++ b/aquaponics/kpis.py
@@ -1,0 +1,28 @@
+"""Key performance indicators for aquaponics systems."""
+
+from __future__ import annotations
+
+
+def feed_conversion_ratio(feed_mass_kg: float, biomass_gain_kg: float) -> float:
+    """Calculate the feed conversion ratio (FCR).
+
+    The FCR is the amount of feed provided divided by the resulting gain in
+    biomass. ``feed_mass_kg`` must be non-negative and ``biomass_gain_kg`` must
+    be greater than zero.
+
+    Args:
+        feed_mass_kg: Mass of feed provided in kilograms.
+        biomass_gain_kg: Increase in biomass in kilograms.
+
+    Returns:
+        The feed conversion ratio as a float.
+
+    Raises:
+        ValueError: If ``feed_mass_kg`` is negative or ``biomass_gain_kg`` is not
+        positive.
+    """
+    if feed_mass_kg < 0:
+        raise ValueError("feed_mass_kg must be non-negative")
+    if biomass_gain_kg <= 0:
+        raise ValueError("biomass_gain_kg must be greater than zero")
+    return feed_mass_kg / biomass_gain_kg

--- a/tests/test_kpis.py
+++ b/tests/test_kpis.py
@@ -1,0 +1,20 @@
+import pytest
+
+from aquaponics import feed_conversion_ratio
+
+
+def test_feed_conversion_ratio_normal_case():
+    assert feed_conversion_ratio(2.0, 1.0) == 2.0
+
+
+def test_feed_conversion_ratio_zero_feed():
+    assert feed_conversion_ratio(0.0, 1.0) == 0.0
+
+
+@pytest.mark.parametrize(
+    "feed_mass_kg, biomass_gain_kg",
+    [(-1.0, 1.0), (1.0, 0.0), (1.0, -0.5)],
+)
+def test_feed_conversion_ratio_invalid_inputs(feed_mass_kg, biomass_gain_kg):
+    with pytest.raises(ValueError):
+        feed_conversion_ratio(feed_mass_kg, biomass_gain_kg)


### PR DESCRIPTION
## Summary
- implement `feed_conversion_ratio` KPI with validation
- expose KPI in the `aquaponics` package
- add unit tests for normal and invalid input cases

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68988c8f5a2483229036513eebcc2b96