### PR TITLE
Add TAN load check utility with tests

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,21 @@
+def tan_load_check(protein_feed_g: float, biofilter_cap_g: float):
+    """Evaluate if the biofilter can handle TAN generated from protein feed.
+
+    Approximately 9.2% of feed protein is converted to total ammonia nitrogen (TAN).
+    This function estimates TAN load and compares it to the biofilter capacity.
+
+    Args:
+        protein_feed_g: Amount of protein feed provided (g).
+        biofilter_cap_g: Biofilter capacity for TAN (g).
+
+    Returns:
+        A tuple ``(utilization_pct, within_capacity)`` where ``utilization_pct`` is
+        the percentage of the biofilter capacity used and ``within_capacity``
+        indicates whether the TAN load is within the biofilter's handling ability.
+    """
+    if biofilter_cap_g <= 0:
+        raise ValueError("biofilter_cap_g must be positive")
+
+    tan_produced = protein_feed_g * 0.092
+    utilization_pct = (tan_produced / biofilter_cap_g) * 100
+    return utilization_pct, utilization_pct <= 100

--- a/tests/test_tan_load.py
+++ b/tests/test_tan_load.py
@@ -1,0 +1,28 @@
+import os
+import sys
+
+import pytest
+
+# Ensure the application package is importable when tests are run directly.
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.utils import tan_load_check
+
+def test_tan_load_within_capacity():
+    utilization, ok = tan_load_check(100, 10)
+    assert utilization == pytest.approx(92.0)
+    assert ok is True
+
+def test_tan_load_exceeds_capacity():
+    utilization, ok = tan_load_check(200, 10)
+    assert utilization == pytest.approx(184.0)
+    assert ok is False
+
+def test_zero_feed():
+    utilization, ok = tan_load_check(0, 10)
+    assert utilization == 0
+    assert ok is True
+
+def test_zero_capacity_raises():
+    with pytest.raises(ValueError):
+        tan_load_check(100, 0)


### PR DESCRIPTION
## Summary
- add `tan_load_check` helper to evaluate TAN load vs biofilter capacity
- document ~9.2% protein-to-TAN conversion in docstring
- implement pytest suite covering normal, excessive, and edge scenarios

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68988c9ceb00832285fff87df93e3910