### PR TITLE
Add validation for alert thresholds

### DIFF
--- a/aquaponics/alerts.py
+++ b/aquaponics/alerts.py
@@ -1,0 +1,46 @@
+"""Alert calculation utilities.
+
+This module provides helpers to derive warning thresholds for a measured
+parameter. The function checks the input configuration for obvious
+mistakes and raises :class:`ValueError` with a descriptive message when
+invalid values are supplied.
+"""
+
+from __future__ import annotations
+
+
+def calculate_warn_range(min_value: float, max_value: float, warn_pct: float):
+    """Compute the warning range between ``min_value`` and ``max_value``.
+
+    Parameters
+    ----------
+    min_value:
+        The minimum acceptable value for the reading.
+    max_value:
+        The maximum acceptable value for the reading. Must be greater
+        than ``min_value``.
+    warn_pct:
+        Fraction of the span between ``min_value`` and ``max_value``
+        used to determine the width of the warning bands. Must satisfy
+        ``0 <= warn_pct < 0.5``.
+
+    Returns
+    -------
+    tuple[float, float]
+        The lower and upper warning thresholds.
+
+    Raises
+    ------
+    ValueError
+        If ``warn_pct`` or the value range are invalid.
+    """
+    if not (0 <= warn_pct < 0.5):
+        raise ValueError("warn_pct must satisfy 0 <= warn_pct < 0.5")
+    if max_value <= min_value:
+        raise ValueError("max_value must be greater than min_value")
+
+    span = max_value - min_value
+    margin = span * warn_pct
+    warn_low = min_value + margin
+    warn_high = max_value - margin
+    return warn_low, warn_high

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure project root is on the import path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from aquaponics.alerts import calculate_warn_range
+
+
+def test_warn_pct_out_of_bounds():
+    with pytest.raises(ValueError, match="0 <= warn_pct < 0.5"):
+        calculate_warn_range(0, 10, -0.1)
+    with pytest.raises(ValueError, match="0 <= warn_pct < 0.5"):
+        calculate_warn_range(0, 10, 0.5)
+
+
+def test_max_value_gt_min_value():
+    with pytest.raises(ValueError, match="max_value must be greater than min_value"):
+        calculate_warn_range(5, 5, 0.1)
+    with pytest.raises(ValueError, match="max_value must be greater than min_value"):
+        calculate_warn_range(10, 5, 0.1)


### PR DESCRIPTION
## Summary
- add `calculate_warn_range` helper with validation for warn_pct and value bounds
- test invalid warn_pct and value range scenarios

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68988ca741e483228feae64f786ff7ef