### PR TITLE
Add inventory ingestion and forecast tracking

### DIFF
--- a/app/inventory.py
+++ b/app/inventory.py
@@ -1,0 +1,89 @@
+from typing import List
+import httpx
+from sqlmodel import Session
+
+from .models import Ingredient, StockBatch, YieldForecast, AdjustmentLog, InventorySnapshot
+
+
+async def pull_current_stocks(api_url: str) -> List[dict]:
+    """Fetch current stock levels from an external service."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(api_url)
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def pull_les_yield_forecasts(api_url: str) -> List[dict]:
+    """Fetch LES yield forecasts from an external service."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(api_url)
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def ingest_inventory(stock_url: str, session: Session) -> None:
+    """Update ingredient stock levels from a remote source."""
+    stocks = await pull_current_stocks(stock_url)
+    for item in stocks:
+        ingredient = session.get(Ingredient, item["ingredient_id"])
+        if ingredient:
+            ingredient.stock_on_hand = item["stock_on_hand"]
+            session.add(
+                InventorySnapshot(
+                    ingredient_id=ingredient.ingredient_id,
+                    stock_on_hand=ingredient.stock_on_hand,
+                )
+            )
+    session.commit()
+
+
+async def ingest_forecasts(forecast_url: str, session: Session) -> None:
+    """Store yield forecasts and update batch metadata."""
+    forecasts = await pull_les_yield_forecasts(forecast_url)
+    for item in forecasts:
+        forecast = YieldForecast(
+            batch_id=item["batch_id"],
+            expected_harvest_date=item.get("expected_harvest_date"),
+            expected_yield_kg=item.get("expected_yield_kg"),
+            yield_std_kg=item.get("yield_std_kg"),
+        )
+        session.add(forecast)
+
+        batch = session.get(StockBatch, item["batch_id"])
+        if not batch:
+            continue
+
+        if forecast.expected_harvest_date and batch.expected_harvest_date != forecast.expected_harvest_date:
+            session.add(
+                AdjustmentLog(
+                    batch_id=batch.batch_id,
+                    field_name="expected_harvest_date",
+                    previous_value=str(batch.expected_harvest_date),
+                    new_value=str(forecast.expected_harvest_date),
+                )
+            )
+            batch.expected_harvest_date = forecast.expected_harvest_date
+
+        if forecast.expected_yield_kg is not None and batch.expected_yield_kg != forecast.expected_yield_kg:
+            session.add(
+                AdjustmentLog(
+                    batch_id=batch.batch_id,
+                    field_name="expected_yield_kg",
+                    previous_value=str(batch.expected_yield_kg),
+                    new_value=str(forecast.expected_yield_kg),
+                )
+            )
+            batch.expected_yield_kg = forecast.expected_yield_kg
+
+        if forecast.yield_std_kg is not None and batch.yield_std_kg != forecast.yield_std_kg:
+            session.add(
+                AdjustmentLog(
+                    batch_id=batch.batch_id,
+                    field_name="yield_std_kg",
+                    previous_value=str(batch.yield_std_kg),
+                    new_value=str(forecast.yield_std_kg),
+                )
+            )
+            batch.yield_std_kg = forecast.yield_std_kg
+
+    session.commit()

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, date
 from typing import List, Optional
 from fastapi import FastAPI, Depends, Query, Request
 from fastapi.templating import Jinja2Templates
@@ -6,8 +6,19 @@ from pydantic import BaseModel
 from sqlmodel import Session, select
 
 from .database import create_db_and_tables, get_session
-from .models import (EventLog, FeedLog, GrowthRecord, Species,
-                     StockBatch, WaterReading, WaterTarget)
+from .models import (
+    AdjustmentLog,
+    EventLog,
+    FeedLog,
+    GrowthRecord,
+    Ingredient,
+    InventorySnapshot,
+    Species,
+    StockBatch,
+    WaterReading,
+    WaterTarget,
+    YieldForecast,
+)
 from .optimization import optimize_feed, optimize_menu
 
 app = FastAPI()
@@ -90,6 +101,87 @@ def calculate_fcr(batch_id: int, session: Session = Depends(get_session)):
     weight_gain = weights[-1] - weights[0]
     fcr = total_feed / weight_gain if weight_gain else None
     return {"batch_id": batch_id, "fcr": fcr}
+
+
+class InventoryUpdate(BaseModel):
+    ingredient_id: int
+    stock_on_hand: float
+
+
+class ForecastUpdate(BaseModel):
+    batch_id: int
+    expected_harvest_date: Optional[date] = None
+    expected_yield_kg: Optional[float] = None
+    yield_std_kg: Optional[float] = None
+
+
+@app.post("/inventory", response_model=Ingredient)
+def update_inventory(update: InventoryUpdate, session: Session = Depends(get_session)):
+    ingredient = session.get(Ingredient, update.ingredient_id)
+    if ingredient:
+        ingredient.stock_on_hand = update.stock_on_hand
+    else:
+        ingredient = Ingredient(
+            ingredient_id=update.ingredient_id,
+            name="unknown",
+            stock_on_hand=update.stock_on_hand,
+        )
+        session.add(ingredient)
+    session.add(
+        InventorySnapshot(
+            ingredient_id=ingredient.ingredient_id,
+            stock_on_hand=ingredient.stock_on_hand,
+        )
+    )
+    session.commit()
+    session.refresh(ingredient)
+    return ingredient
+
+
+@app.post("/forecasts", response_model=YieldForecast)
+def update_forecast(update: ForecastUpdate, session: Session = Depends(get_session)):
+    forecast = YieldForecast(
+        batch_id=update.batch_id,
+        expected_harvest_date=update.expected_harvest_date,
+        expected_yield_kg=update.expected_yield_kg,
+        yield_std_kg=update.yield_std_kg,
+    )
+    session.add(forecast)
+    batch = session.get(StockBatch, update.batch_id)
+    if batch:
+        if update.expected_harvest_date and batch.expected_harvest_date != update.expected_harvest_date:
+            session.add(
+                AdjustmentLog(
+                    batch_id=batch.batch_id,
+                    field_name="expected_harvest_date",
+                    previous_value=str(batch.expected_harvest_date),
+                    new_value=str(update.expected_harvest_date),
+                )
+            )
+            batch.expected_harvest_date = update.expected_harvest_date
+        if update.expected_yield_kg is not None and batch.expected_yield_kg != update.expected_yield_kg:
+            session.add(
+                AdjustmentLog(
+                    batch_id=batch.batch_id,
+                    field_name="expected_yield_kg",
+                    previous_value=str(batch.expected_yield_kg),
+                    new_value=str(update.expected_yield_kg),
+                )
+            )
+            batch.expected_yield_kg = update.expected_yield_kg
+        if update.yield_std_kg is not None and batch.yield_std_kg != update.yield_std_kg:
+            session.add(
+                AdjustmentLog(
+                    batch_id=batch.batch_id,
+                    field_name="yield_std_kg",
+                    previous_value=str(batch.yield_std_kg),
+                    new_value=str(update.yield_std_kg),
+                )
+            )
+            batch.yield_std_kg = update.yield_std_kg
+    session.commit()
+    session.refresh(forecast)
+    return forecast
 
 
 class IngredientInput(BaseModel):

--- a/app/models.py
+++ b/app/models.py
@@ -13,6 +13,9 @@ class StockBatch(SQLModel, table=True):
     batch_id: Optional[int] = Field(default=None, primary_key=True)
     species_id: int = Field(foreign_key="species.species_id")
     start_date: Optional[date] = None
+    expected_harvest_date: Optional[date] = None
+    expected_yield_kg: Optional[float] = None
+    yield_std_kg: Optional[float] = None
 
 class WaterTarget(SQLModel, table=True):
     __tablename__ = "water_targets"
@@ -62,6 +65,14 @@ class Ingredient(SQLModel, table=True):
     source: Optional[str] = None
 
 
+class InventorySnapshot(SQLModel, table=True):
+    __tablename__ = "inventory_snapshots"
+    snapshot_id: Optional[int] = Field(default=None, primary_key=True)
+    ingredient_id: int = Field(foreign_key="ingredients.ingredient_id")
+    stock_on_hand: float
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
+
+
 class FeedIngredient(SQLModel, table=True):
     __tablename__ = "feed_ingredients"
     ingredient_id: Optional[int] = Field(default=None, primary_key=True)
@@ -77,3 +88,23 @@ class Nutrient(SQLModel, table=True):
     nutrient_id: Optional[int] = Field(default=None, primary_key=True)
     name: str
     unit: str
+
+
+class YieldForecast(SQLModel, table=True):
+    __tablename__ = "yield_forecasts"
+    forecast_id: Optional[int] = Field(default=None, primary_key=True)
+    batch_id: int = Field(foreign_key="stock_batches.batch_id")
+    forecast_time: datetime = Field(default_factory=datetime.utcnow)
+    expected_harvest_date: Optional[date] = None
+    expected_yield_kg: Optional[float] = None
+    yield_std_kg: Optional[float] = None
+
+
+class AdjustmentLog(SQLModel, table=True):
+    __tablename__ = "adjustment_logs"
+    adjustment_id: Optional[int] = Field(default=None, primary_key=True)
+    batch_id: int = Field(foreign_key="stock_batches.batch_id")
+    field_name: str
+    previous_value: Optional[str] = None
+    new_value: Optional[str] = None
+    timestamp: datetime = Field(default_factory=datetime.utcnow)


### PR DESCRIPTION
## Summary
- add asynchronous inventory ingestion service to pull stock levels and yield forecasts
- extend models with harvest dates, yield uncertainty, history, and adjustment logs
- expose `/inventory` and `/forecasts` endpoints for sensors to push updates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689899ab63788322a570dc54f1ba232a