### PR TITLE
Add food/feed tables and ETL loaders

### DIFF
--- a/app/etl/__init__.py
+++ b/app/etl/__init__.py
@@ -1,0 +1,17 @@
+"""ETL helpers for loading reference datasets.
+
+Each module exposes a ``load(session, data_file=None)`` function that
+reads a CSV file and populates the database.
+"""
+
+from .ausnut import load as load_ausnut
+from .fdc import load as load_fdc
+from .feedipedia import load as load_feedipedia
+from .aquaculture import load as load_aquaculture
+
+__all__ = [
+    "load_ausnut",
+    "load_fdc",
+    "load_feedipedia",
+    "load_aquaculture",
+]

--- a/app/etl/aquaculture.py
+++ b/app/etl/aquaculture.py
@@ -1,0 +1,32 @@
+"""ETL for aquaculture feed tables."""
+
+import csv
+from pathlib import Path
+from sqlmodel import Session, select
+from ..models import FeedIngredient, SourceTag
+
+DATA_FILE = Path(__file__).resolve().parents[2] / "data" / "aquaculture.csv"
+
+
+def load(session: Session, data_file: Path = DATA_FILE) -> None:
+    """Load aquaculture CSV data into the FeedIngredient table."""
+    if not data_file.exists():
+        return
+
+    tag = session.exec(select(SourceTag).where(SourceTag.name == "Aquaculture Table")).first()
+    if not tag:
+        tag = SourceTag(name="Aquaculture Table")
+        session.add(tag)
+        session.commit()
+        session.refresh(tag)
+
+    with data_file.open() as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            ingredient = FeedIngredient(
+                name=row["name"],
+                source_tag_id=tag.tag_id,
+                available_on_farm=row.get("available_on_farm", "").lower() == "true",
+            )
+            session.add(ingredient)
+    session.commit()

--- a/app/etl/ausnut.py
+++ b/app/etl/ausnut.py
@@ -1,0 +1,36 @@
+"""ETL for AUSNUT food composition data."""
+
+import csv
+from pathlib import Path
+from sqlmodel import Session, select
+from ..models import HumanFood, SourceTag
+
+DATA_FILE = Path(__file__).resolve().parents[2] / "data" / "ausnut.csv"
+
+
+def load(session: Session, data_file: Path = DATA_FILE) -> None:
+    """Load AUSNUT CSV data into the HumanFood table.
+
+    The CSV is expected to contain at least a ``name`` column and an optional
+    ``available_on_farm`` boolean column.
+    """
+    if not data_file.exists():
+        return
+
+    tag = session.exec(select(SourceTag).where(SourceTag.name == "AUSNUT")).first()
+    if not tag:
+        tag = SourceTag(name="AUSNUT")
+        session.add(tag)
+        session.commit()
+        session.refresh(tag)
+
+    with data_file.open() as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            food = HumanFood(
+                name=row["name"],
+                source_tag_id=tag.tag_id,
+                available_on_farm=row.get("available_on_farm", "").lower() == "true",
+            )
+            session.add(food)
+    session.commit()

--- a/app/etl/fdc.py
+++ b/app/etl/fdc.py
@@ -1,0 +1,32 @@
+"""ETL for USDA FoodData Central."""
+
+import csv
+from pathlib import Path
+from sqlmodel import Session, select
+from ..models import HumanFood, SourceTag
+
+DATA_FILE = Path(__file__).resolve().parents[2] / "data" / "fdc.csv"
+
+
+def load(session: Session, data_file: Path = DATA_FILE) -> None:
+    """Load USDA FDC CSV data into the HumanFood table."""
+    if not data_file.exists():
+        return
+
+    tag = session.exec(select(SourceTag).where(SourceTag.name == "USDA FDC")).first()
+    if not tag:
+        tag = SourceTag(name="USDA FDC")
+        session.add(tag)
+        session.commit()
+        session.refresh(tag)
+
+    with data_file.open() as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            food = HumanFood(
+                name=row["name"],
+                source_tag_id=tag.tag_id,
+                available_on_farm=row.get("available_on_farm", "").lower() == "true",
+            )
+            session.add(food)
+    session.commit()

--- a/app/etl/feedipedia.py
+++ b/app/etl/feedipedia.py
@@ -1,0 +1,32 @@
+"""ETL for Feedipedia feed ingredient data."""
+
+import csv
+from pathlib import Path
+from sqlmodel import Session, select
+from ..models import FeedIngredient, SourceTag
+
+DATA_FILE = Path(__file__).resolve().parents[2] / "data" / "feedipedia.csv"
+
+
+def load(session: Session, data_file: Path = DATA_FILE) -> None:
+    """Load Feedipedia CSV data into the FeedIngredient table."""
+    if not data_file.exists():
+        return
+
+    tag = session.exec(select(SourceTag).where(SourceTag.name == "Feedipedia")).first()
+    if not tag:
+        tag = SourceTag(name="Feedipedia")
+        session.add(tag)
+        session.commit()
+        session.refresh(tag)
+
+    with data_file.open() as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            ingredient = FeedIngredient(
+                name=row["name"],
+                source_tag_id=tag.tag_id,
+                available_on_farm=row.get("available_on_farm", "").lower() == "true",
+            )
+            session.add(ingredient)
+    session.commit()

--- a/app/models.py
+++ b/app/models.py
@@ -51,15 +51,20 @@ class EventLog(SQLModel, table=True):
     message: str
     timestamp: datetime = Field(default_factory=datetime.utcnow)
 
-
-class Ingredient(SQLModel, table=True):
-    __tablename__ = "ingredients"
-    ingredient_id: Optional[int] = Field(default=None, primary_key=True)
+class SourceTag(SQLModel, table=True):
+    __tablename__ = "source_tags"
+    tag_id: Optional[int] = Field(default=None, primary_key=True)
     name: str
-    unit: str = "kg"
-    cost_per_kg: float = 0
-    stock_on_hand: float = 0
-    source: Optional[str] = None
+    on_farm: bool = False
+    description: Optional[str] = None
+
+
+class HumanFood(SQLModel, table=True):
+    __tablename__ = "human_foods"
+    food_id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+    source_tag_id: Optional[int] = Field(default=None, foreign_key="source_tags.tag_id")
+    available_on_farm: bool = False
 
 
 class FeedIngredient(SQLModel, table=True):
@@ -69,7 +74,26 @@ class FeedIngredient(SQLModel, table=True):
     unit: str = "kg"
     cost_per_kg: float = 0
     stock_on_hand: float = 0
-    source: Optional[str] = None
+    source_tag_id: Optional[int] = Field(default=None, foreign_key="source_tags.tag_id")
+    available_on_farm: bool = False
+
+
+class SeasonalYield(SQLModel, table=True):
+    __tablename__ = "seasonal_yields"
+    yield_id: Optional[int] = Field(default=None, primary_key=True)
+    food_id: Optional[int] = Field(default=None, foreign_key="human_foods.food_id")
+    ingredient_id: Optional[int] = Field(default=None, foreign_key="feed_ingredients.ingredient_id")
+    season: str
+    yield_kg: float
+
+
+class ProcessingLossFactor(SQLModel, table=True):
+    __tablename__ = "processing_loss_factors"
+    loss_id: Optional[int] = Field(default=None, primary_key=True)
+    food_id: Optional[int] = Field(default=None, foreign_key="human_foods.food_id")
+    ingredient_id: Optional[int] = Field(default=None, foreign_key="feed_ingredients.ingredient_id")
+    process: str
+    loss_factor: float
 
 
 class Nutrient(SQLModel, table=True):

--- a/app/seed.py
+++ b/app/seed.py
@@ -1,6 +1,15 @@
 from sqlmodel import Session, select
 from .database import engine, create_db_and_tables
-from .models import Species, WaterTarget
+from .models import (
+    Species,
+    WaterTarget,
+    SourceTag,
+    HumanFood,
+    FeedIngredient,
+    SeasonalYield,
+    ProcessingLossFactor,
+)
+from .etl import load_ausnut, load_fdc, load_feedipedia, load_aquaculture
 
 def seed():
     create_db_and_tables()
@@ -22,6 +31,49 @@ def seed():
             ]
             for t in targets:
                 session.add(WaterTarget(**t))
+
+        if not session.exec(select(SourceTag)).first():
+            tags = [
+                {"name": "AUSNUT"},
+                {"name": "USDA FDC"},
+                {"name": "Feedipedia"},
+                {"name": "Aquaculture Table"},
+            ]
+            for t in tags:
+                session.add(SourceTag(**t))
+
+        session.commit()
+
+        # Run ETL loaders (they silently skip if data files are missing)
+        load_ausnut(session)
+        load_fdc(session)
+        load_feedipedia(session)
+        load_aquaculture(session)
+
+        if not session.exec(select(HumanFood)).first():
+            ausnut_tag = session.exec(
+                select(SourceTag).where(SourceTag.name == "AUSNUT")
+            ).first()
+            session.add(HumanFood(name="Tomato", source_tag_id=ausnut_tag.tag_id, available_on_farm=True))
+            session.add(HumanFood(name="Rice", source_tag_id=ausnut_tag.tag_id, available_on_farm=False))
+
+        if not session.exec(select(FeedIngredient)).first():
+            feed_tag = session.exec(
+                select(SourceTag).where(SourceTag.name == "Feedipedia")
+            ).first()
+            session.add(FeedIngredient(name="Soy Meal", source_tag_id=feed_tag.tag_id, available_on_farm=False))
+            session.add(FeedIngredient(name="Duckweed", source_tag_id=feed_tag.tag_id, available_on_farm=True))
+
+        if not session.exec(select(SeasonalYield)).first():
+            tomato = session.exec(select(HumanFood).where(HumanFood.name == "Tomato")).first()
+            if tomato:
+                session.add(SeasonalYield(food_id=tomato.food_id, season="Summer", yield_kg=1.2))
+
+        if not session.exec(select(ProcessingLossFactor)).first():
+            tomato = session.exec(select(HumanFood).where(HumanFood.name == "Tomato")).first()
+            if tomato:
+                session.add(ProcessingLossFactor(food_id=tomato.food_id, process="Cleaning", loss_factor=0.1))
+
         session.commit()
 
 if __name__ == "__main__":

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,0 +1,32 @@
+# Database schema and data import
+
+This project models additional concepts needed for diet and feed planning.
+The new tables introduced are:
+
+- `source_tags` – identifies the data source for an item and whether it is
+  produced on the farm.
+- `human_foods` – foods for human consumption sourced from AUSNUT and USDA
+  FoodData Central. Each record optionally links to a `source_tags` entry and
+  marks `available_on_farm`.
+- `feed_ingredients` – ingredients for animal feed. Records may come from
+  Feedipedia or aquaculture tables and also link to `source_tags`.
+- `seasonal_yields` – expected production in kilograms for a given season for
+  a human food or feed ingredient.
+- `processing_loss_factors` – fraction of weight lost during processing steps
+  such as cleaning or drying.
+
+## Import process
+
+ETL helpers live in `app/etl/`. Each module exposes a `load(session)` function
+that reads a CSV file from the `data/` directory and populates the database.
+The seed script (`app/seed.py`) calls all loaders after creating the tables.
+CSV files are optional; if a file is missing the loader simply skips it.
+
+Example:
+
+```bash
+python -m app.seed  # creates tables and loads available datasets
+```
+
+CSV files should include at least a `name` column and may include an
+`available_on_farm` boolean column to flag local production.

--- a/schema.sql
+++ b/schema.sql
@@ -97,3 +97,45 @@ CREATE TABLE event_logs (
     timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     location TEXT
 );
+
+-- New tables for human foods and feed ingredients
+
+CREATE TABLE source_tags (
+    tag_id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT,
+    on_farm BOOLEAN DEFAULT FALSE
+);
+
+CREATE TABLE human_foods (
+    food_id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    source_tag_id INTEGER REFERENCES source_tags(tag_id),
+    available_on_farm BOOLEAN DEFAULT FALSE
+);
+
+CREATE TABLE feed_ingredients (
+    ingredient_id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    unit TEXT DEFAULT 'kg',
+    cost_per_kg DECIMAL DEFAULT 0,
+    stock_on_hand DECIMAL DEFAULT 0,
+    source_tag_id INTEGER REFERENCES source_tags(tag_id),
+    available_on_farm BOOLEAN DEFAULT FALSE
+);
+
+CREATE TABLE seasonal_yields (
+    yield_id SERIAL PRIMARY KEY,
+    food_id INTEGER REFERENCES human_foods(food_id),
+    ingredient_id INTEGER REFERENCES feed_ingredients(ingredient_id),
+    season TEXT NOT NULL,
+    yield_kg DECIMAL
+);
+
+CREATE TABLE processing_loss_factors (
+    loss_id SERIAL PRIMARY KEY,
+    food_id INTEGER REFERENCES human_foods(food_id),
+    ingredient_id INTEGER REFERENCES feed_ingredients(ingredient_id),
+    process TEXT NOT NULL,
+    loss_factor DECIMAL
+);


### PR DESCRIPTION
## Summary
- extend schema and SQLModel classes with human food, feed ingredient, source tag, seasonal yield and processing loss tables
- add ETL modules to load AUSNUT, USDA FDC, Feedipedia and aquaculture CSVs
- expand seed script to load datasets and mark on-farm availability; add schema/import docs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689899bd7738832291538de1e590fa0b