### PR TITLE
feat: add inventory-aware menu/feed optimization with DB integration

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -1,4 +1,12 @@
-from sqlmodel import SQLModel, create_engine, Session
+from typing import Dict, List, Tuple
+from sqlmodel import SQLModel, create_engine, Session, select
+
+from .models import (
+    FeedIngredient,
+    FeedRequirement,
+    Ingredient,
+    PersonaRequirement,
+)
 
 DATABASE_URL = "sqlite:///aquaponics.db"
 
@@ -13,3 +21,53 @@ def create_db_and_tables():
 def get_session():
     with Session(engine) as session:
         yield session
+
+
+def get_menu_inputs(
+    session: Session, persona: str
+) -> Tuple[List[Dict], Dict[str, float], Dict[str, float], Dict[str, float], Dict[str, float]]:
+    """Fetch ingredients, requirements and constraints for a persona."""
+
+    ingredients: List[Dict] = []
+    preferences: Dict[str, float] = {}
+    caps: Dict[str, float] = {}
+    inventory: Dict[str, float] = {}
+    for ing in session.exec(select(Ingredient)).all():
+        ingredients.append(
+            {"name": ing.name, "cost": ing.cost_per_kg, "nutrients": ing.nutrients}
+        )
+        inventory[ing.name] = ing.stock_on_hand
+        if ing.cap is not None:
+            caps[ing.name] = ing.cap
+        if persona in ing.preferences:
+            preferences[ing.name] = ing.preferences[persona]
+
+    requirements: Dict[str, float] = {}
+    query = select(PersonaRequirement).where(PersonaRequirement.persona == persona)
+    for req in session.exec(query).all():
+        requirements[req.nutrient] = req.amount
+
+    return ingredients, requirements, preferences, caps, inventory
+
+
+def get_feed_inputs(
+    session: Session,
+) -> Tuple[List[Dict], Dict[str, float], Dict[str, float], Dict[str, float]]:
+    """Fetch feed formulation inputs from the database."""
+
+    ingredients: List[Dict] = []
+    caps: Dict[str, float] = {}
+    inventory: Dict[str, float] = {}
+    for ing in session.exec(select(FeedIngredient)).all():
+        ingredients.append(
+            {"name": ing.name, "cost": ing.cost_per_kg, "nutrients": ing.nutrients}
+        )
+        inventory[ing.name] = ing.stock_on_hand
+        if ing.cap is not None:
+            caps[ing.name] = ing.cap
+
+    requirements: Dict[str, float] = {}
+    for req in session.exec(select(FeedRequirement)).all():
+        requirements[req.nutrient] = req.amount
+
+    return ingredients, requirements, caps, inventory

--- a/app/main.py
+++ b/app/main.py
@@ -9,6 +9,7 @@ from .database import create_db_and_tables, get_session
 from .models import (EventLog, FeedLog, GrowthRecord, Species,
                      StockBatch, WaterReading, WaterTarget)
 from .optimization import optimize_feed, optimize_menu
+from .utils import run_optimizations
 
 app = FastAPI()
 templates = Jinja2Templates(directory="app/templates")
@@ -115,3 +116,9 @@ def fish_feed(req: OptimizationRequest):
     ingredients = [i.dict() for i in req.ingredients]
     solution = optimize_feed(ingredients, req.requirements)
     return solution
+
+
+@app.get("/optimize/aggregate")
+def optimize_aggregate(persona: str, session: Session = Depends(get_session)):
+    """Run both optimizers using database data and aggregate results."""
+    return run_optimizations(session, persona)

--- a/app/models.py
+++ b/app/models.py
@@ -1,6 +1,7 @@
 from datetime import datetime, date
-from typing import Optional
+from typing import Dict, Optional
 from sqlmodel import SQLModel, Field
+from sqlalchemy import Column, JSON
 
 class Species(SQLModel, table=True):
     __tablename__ = "species"
@@ -60,6 +61,9 @@ class Ingredient(SQLModel, table=True):
     cost_per_kg: float = 0
     stock_on_hand: float = 0
     source: Optional[str] = None
+    nutrients: Dict[str, float] = Field(default_factory=dict, sa_column=Column(JSON))
+    preferences: Dict[str, float] = Field(default_factory=dict, sa_column=Column(JSON))
+    cap: Optional[float] = None
 
 
 class FeedIngredient(SQLModel, table=True):
@@ -70,6 +74,8 @@ class FeedIngredient(SQLModel, table=True):
     cost_per_kg: float = 0
     stock_on_hand: float = 0
     source: Optional[str] = None
+    nutrients: Dict[str, float] = Field(default_factory=dict, sa_column=Column(JSON))
+    cap: Optional[float] = None
 
 
 class Nutrient(SQLModel, table=True):
@@ -77,3 +83,22 @@ class Nutrient(SQLModel, table=True):
     nutrient_id: Optional[int] = Field(default=None, primary_key=True)
     name: str
     unit: str
+
+
+class PersonaRequirement(SQLModel, table=True):
+    """Nutrient requirements for a given persona."""
+
+    __tablename__ = "persona_requirements"
+    id: Optional[int] = Field(default=None, primary_key=True)
+    persona: str
+    nutrient: str
+    amount: float
+
+
+class FeedRequirement(SQLModel, table=True):
+    """Global nutrient requirements for formulating feed."""
+
+    __tablename__ = "feed_requirements"
+    id: Optional[int] = Field(default=None, primary_key=True)
+    nutrient: str
+    amount: float

--- a/app/optimization.py
+++ b/app/optimization.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 try:
     from ortools.linear_solver import pywraplp
@@ -6,25 +6,49 @@ except Exception:  # pragma: no cover - fallback when ortools missing
     pywraplp = None
 
 
-def optimize_menu(ingredients: List[Dict], requirements: Dict[str, float]) -> Dict[str, float]:
-    """Simple linear program for a human menu.
+def optimize_menu(
+    ingredients: List[Dict],
+    requirements: Dict[str, float],
+    preferences: Optional[Dict[str, float]] = None,
+    caps: Optional[Dict[str, float]] = None,
+    inventory: Optional[Dict[str, float]] = None,
+) -> Dict[str, float]:
+    """Simple linear program for a human menu with optional constraints.
 
     Args:
         ingredients: list of dicts with keys name, cost, nutrients (dict).
         requirements: nutrient -> minimum requirement.
+        preferences: ingredient -> bonus/penalty applied to objective (positive favors).
+        caps: ingredient -> maximum inclusion amount.
+        inventory: ingredient -> available inventory shared across personas.
     Returns:
         dict mapping ingredient names to grams per day.
     """
+    preferences = preferences or {}
+    caps = caps or {}
+    inventory = inventory or {}
+
     if pywraplp:
         solver = pywraplp.Solver.CreateSolver("GLOP")
         if solver is None:
             raise RuntimeError("GLOP solver unavailable")
 
-        variables = {
-            ing["name"]: solver.NumVar(0, solver.infinity(), ing["name"]) for ing in ingredients
-        }
+        variables = {}
+        for ing in ingredients:
+            name = ing["name"]
+            upper = solver.infinity()
+            if name in caps:
+                upper = min(upper, caps[name])
+            if name in inventory:
+                upper = min(upper, inventory[name])
+            variables[name] = solver.NumVar(0, upper, name)
+
         solver.Minimize(
-            solver.Sum(variables[ing["name"]] * ing.get("cost", 0) for ing in ingredients)
+            solver.Sum(
+                variables[ing["name"]]
+                * (ing.get("cost", 0) - preferences.get(ing["name"], 0))
+                for ing in ingredients
+            )
         )
 
         for nutrient, minimum in requirements.items():
@@ -44,29 +68,60 @@ def optimize_menu(ingredients: List[Dict], requirements: Dict[str, float]) -> Di
     # Fallback: pick cheapest ingredient satisfying each nutrient independently
     solution: Dict[str, float] = {ing["name"]: 0 for ing in ingredients}
     for nutrient, minimum in requirements.items():
-        best = min(
+        remaining = minimum
+        # sort ingredients by adjusted cost per unit nutrient
+        sorted_ings = sorted(
             ingredients,
             key=lambda ing: (
                 float("inf")
                 if ing["nutrients"].get(nutrient, 0) == 0
-                else ing.get("cost", 0) / ing["nutrients"].get(nutrient, 0)
+                else (ing.get("cost", 0) - preferences.get(ing["name"], 0))
+                / ing["nutrients"].get(nutrient, 0)
             ),
         )
-        needed = minimum / best["nutrients"].get(nutrient, 1)
-        solution[best["name"]] = max(solution[best["name"]], needed)
+        for ing in sorted_ings:
+            contrib = ing["nutrients"].get(nutrient, 0)
+            if contrib <= 0:
+                continue
+            name = ing["name"]
+            allowed = min(
+                caps.get(name, float("inf")),
+                inventory.get(name, float("inf")),
+            )
+            available = max(0, allowed - solution[name])
+            if available <= 0:
+                continue
+            take = min(remaining / contrib, available)
+            solution[name] += take
+            remaining -= take * contrib
+            if remaining <= 0:
+                break
     return solution
 
 
-def optimize_feed(ingredients: List[Dict], requirements: Dict[str, float]) -> Dict[str, float]:
-    """Least cost fish feed formulation."""
+def optimize_feed(
+    ingredients: List[Dict],
+    requirements: Dict[str, float],
+    caps: Optional[Dict[str, float]] = None,
+    inventory: Optional[Dict[str, float]] = None,
+) -> Dict[str, float]:
+    """Least cost fish feed formulation with optional caps and inventory limits."""
+    caps = caps or {}
+    inventory = inventory or {}
     if pywraplp:
         solver = pywraplp.Solver.CreateSolver("GLOP")
         if solver is None:
             raise RuntimeError("GLOP solver unavailable")
 
-        variables = {
-            ing["name"]: solver.NumVar(0, 1, ing["name"]) for ing in ingredients
-        }
+        variables = {}
+        for ing in ingredients:
+            name = ing["name"]
+            upper = 1.0
+            if name in caps:
+                upper = min(upper, caps[name])
+            if name in inventory:
+                upper = min(upper, inventory[name])
+            variables[name] = solver.NumVar(0, upper, name)
         solver.Add(solver.Sum(variables.values()) == 1)
         solver.Minimize(
             solver.Sum(variables[ing["name"]] * ing.get("cost", 0) for ing in ingredients)
@@ -89,7 +144,8 @@ def optimize_feed(ingredients: List[Dict], requirements: Dict[str, float]) -> Di
     # Fallback heuristic: allocate nutrient using cheapest ingredient
     solution: Dict[str, float] = {ing["name"]: 0 for ing in ingredients}
     for nutrient, minimum in requirements.items():
-        best = min(
+        remaining = minimum
+        sorted_ings = sorted(
             ingredients,
             key=lambda ing: (
                 float("inf")
@@ -97,7 +153,22 @@ def optimize_feed(ingredients: List[Dict], requirements: Dict[str, float]) -> Di
                 else ing.get("cost", 0) / ing["nutrients"].get(nutrient, 0)
             ),
         )
-        needed = minimum / best["nutrients"].get(nutrient, 1)
-        solution[best["name"]] = max(solution[best["name"]], needed)
+        for ing in sorted_ings:
+            contrib = ing["nutrients"].get(nutrient, 0)
+            if contrib <= 0:
+                continue
+            name = ing["name"]
+            allowed = min(
+                caps.get(name, float("inf")),
+                inventory.get(name, float("inf")),
+            )
+            available = max(0, allowed - solution[name])
+            if available <= 0:
+                continue
+            take = min(remaining / contrib, available)
+            solution[name] += take
+            remaining -= take * contrib
+            if remaining <= 0:
+                break
     total = sum(solution.values()) or 1.0
     return {name: value / total for name, value in solution.items()}

--- a/app/utils.py
+++ b/app/utils.py
@@ -19,3 +19,41 @@ def tan_load_check(protein_feed_g: float, biofilter_cap_g: float):
     tan_produced = protein_feed_g * 0.092
     utilization_pct = (tan_produced / biofilter_cap_g) * 100
     return utilization_pct, utilization_pct <= 100
+
+
+from typing import Dict
+from sqlmodel import Session
+
+from .database import get_feed_inputs, get_menu_inputs
+from .optimization import optimize_feed, optimize_menu
+
+
+def run_optimizations(session: Session, persona: str) -> Dict[str, Dict[str, float]]:
+    """Run both menu and feed optimizations and aggregate the results."""
+
+    menu_inputs = get_menu_inputs(session, persona)
+    menu_solution = optimize_menu(*menu_inputs)
+
+    feed_inputs = get_feed_inputs(session)
+    feed_solution = optimize_feed(*feed_inputs)
+
+    return {"menu": menu_solution, "feed": feed_solution}
+
+
+def _cli(persona: str) -> None:
+    """Simple CLI for running both optimizers."""
+    from .database import get_engine
+
+    engine = get_engine()
+    with Session(engine) as session:
+        result = run_optimizations(session, persona)
+    print(result)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual utility
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run optimizations")
+    parser.add_argument("persona", help="Persona name for menu optimization")
+    args = parser.parse_args()
+    _cli(args.persona)

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -1,4 +1,13 @@
 from app.optimization import optimize_feed, optimize_menu
+from sqlmodel import SQLModel, Session, create_engine
+
+from app.models import (
+    FeedIngredient,
+    FeedRequirement,
+    Ingredient,
+    PersonaRequirement,
+)
+from app.utils import run_optimizations
 
 
 def test_optimize_feed():
@@ -22,3 +31,74 @@ def test_optimize_menu():
     result = optimize_menu(ingredients, requirements)
     protein = sum(result[i["name"]] * i["nutrients"]["protein"] for i in ingredients)
     assert protein >= requirements["protein"] - 1e-6
+
+
+def test_optimize_menu_caps_inventory():
+    ingredients = [
+        {"name": "a", "cost": 1.0, "nutrients": {"protein": 1}},
+        {"name": "b", "cost": 1.0, "nutrients": {"protein": 1}},
+    ]
+    requirements = {"protein": 6}
+    caps = {"a": 4}
+    inventory = {"a": 5, "b": 2}
+    result = optimize_menu(ingredients, requirements, caps=caps, inventory=inventory)
+    assert result["a"] <= 4 + 1e-6
+    assert result["b"] <= 2 + 1e-6
+    protein = sum(result[i["name"]] * i["nutrients"]["protein"] for i in ingredients)
+    assert protein >= requirements["protein"] - 1e-6
+
+
+def test_run_optimizations_with_db():
+    engine = create_engine("sqlite://")
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        session.add(
+            Ingredient(
+                name="a",
+                cost_per_kg=1,
+                stock_on_hand=5,
+                nutrients={"protein": 1},
+                cap=4,
+            )
+        )
+        session.add(
+            Ingredient(
+                name="b",
+                cost_per_kg=1,
+                stock_on_hand=2,
+                nutrients={"protein": 1},
+            )
+        )
+        session.add(
+            PersonaRequirement(persona="p1", nutrient="protein", amount=6)
+        )
+        session.add(
+            FeedIngredient(
+                name="f1",
+                cost_per_kg=1,
+                stock_on_hand=1,
+                nutrients={"protein": 1},
+                cap=0.5,
+            )
+        )
+        session.add(
+            FeedIngredient(
+                name="f2",
+                cost_per_kg=2,
+                stock_on_hand=1,
+                nutrients={"protein": 1},
+            )
+        )
+        session.add(FeedRequirement(nutrient="protein", amount=1))
+        session.commit()
+        result = run_optimizations(session, "p1")
+
+    menu = result["menu"]
+    assert menu["a"] <= 4 + 1e-6
+    assert menu["b"] <= 2 + 1e-6
+    protein = menu["a"] + menu["b"]
+    assert protein >= 6 - 1e-6
+
+    feed = result["feed"]
+    assert feed["f1"] <= 0.5 + 1e-6
+    assert abs(sum(feed.values()) - 1.0) < 1e-6


### PR DESCRIPTION
## Summary
- support preferences, caps, and shared inventory in human menu and fish feed optimizers
- add repository helpers and aggregation utilities to pull optimization data from DB
- expose combined optimization endpoint and CLI, with tests for inventory and nutrient limits

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689899c582e883228b081c9b791854fa