### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest ruff black
+      - name: Lint with ruff
+        run: ruff check .
+      - name: Check formatting with black
+        run: black --check .
+      - name: Run tests
+        run: pytest


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run ruff, black and pytest on Python 3.10 through 3.12

## Testing
- `ruff check .` *(fails: F811, E402 and other errors)*
- `black --check .` *(fails: would reformat and parse errors)*
- `pytest` *(fails: SyntaxError in aquaponics/kpis.py and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_689c712d2f288322949141cee34303fe